### PR TITLE
separate component

### DIFF
--- a/schemas/v2/schema.yaml
+++ b/schemas/v2/schema.yaml
@@ -10,9 +10,8 @@ externalDocs:
 paths: {}
 components:
   schemas:
-    JobProtocol:
+    OpenPAIComponent:
       type: object
-      description: Job protocol specification.
       properties:
         protocolVersion:
           oneOf:
@@ -23,16 +22,10 @@ components:
         name:
           type: string
           description: String in ^[a-zA-Z0-9_-]+$ format, no longer than 255 characters.
-          pattern: "^[a-zA-Z0-9_-]+$"
+          pattern: '^[a-zA-Z0-9_-]+$'
           minLength: 1
           maxLength: 255
           example: tensorflow_distributed_training
-        type:
-          type: string
-          description: Component type, should be "job" here.
-          enum:
-            - job
-          example: job
         version:
           type: string
           description: Component version, default is latest.
@@ -43,403 +36,413 @@ components:
         description:
           type: string
           example: Here is the job description.
-        prerequisites:
-          type: array
-          description: Each item is the protocol for data, script, dockerimage, or output type.
-          items:
-            allOf:
-              - type: object
-                properties:
-                  protocolVersion:
-                    oneOf:
-                      - type: number
-                      - type: string
-                    description: If omitted, follow the protocolVersion in root.
-                    example: 2
-                  name:
-                    type: string
-                    description: Component name.
-                  version:
-                    type: string
-                    description: Component version, default is latest.
-                    example: latest
-                  contributor:
-                    type: string
-                  description:
-                    type: string
-                required:
-                  - name
-              - oneOf:
-                - type: object
-                  properties:
-                    type:
-                      type: string
-                      description: Component type.
-                      enum:
-                        - dockerimage
-                    auth:
-                      type: object
-                      description: Only available when the type is dockerimage.
-                      properties:
-                        username:
-                          type: string
-                        password:
-                          type: string
-                          description: If a password is needed, it should be referenced as a secret.
-                        registryuri:
-                          type: string
-                    uri:
-                      type: string
-                  required:
-                    - type
-                    - uri
-                - type: object
-                  properties:
-                    type:
-                      type: string
-                      description: Component type.
-                      enum:
-                        - script
-                        - output
-                    uri:
-                      type: string
-                  required:
-                    - type
-                    - uri
-                - type: object
-                  properties:
-                    type:
-                      type: string
-                      description: Component type.
-                      enum:
-                        - data
-                    uri:
-                      type: array
-                      items:
-                        type: string
-                      minItems: 1
-                  required:
-                    - type
-                    - uri
-          minItems: 1
-          example:
-            - protocolVersion: 2
-              name: tf_example
-              type: dockerimage
-              version: latest
-              contributor: Alice
-              description: python3.5, tensorflow
-              auth:
-                username: user
-                password: <% $secrets.docker_password %>
-                registryuri: openpai.azurecr.io
-              uri: openpai/pai.example.tensorflow
-            - protocolVersion: 2
-              name: tensorflow_cifar10_model
-              type: output
-              version: latest
-              contributor: Alice
-              description: cifar10 data output
-              uri: hdfs://10.151.40.179:9000/core/cifar10_model
-            - protocolVersion: 2
-              name: tensorflow_cnnbenchmarks
-              type: script
-              version: 84820935288cab696c9c2ac409cbd46a1f24723d
-              contributor: MaggieQi
-              description: tensorflow benchmarks
-              uri: github.com/MaggieQi/benchmarks
-            - protocolVersion: 2
-              name: cifar10
-              type: data
-              version: latest
-              contributor: Alice
-              description: cifar10 dataset, image classification
-              uri:
-                - https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
-        parameters:
-          type: object
-          description: |
-            If specified, the whole parameters object can be referenced as `$parameters`.
-            Scope of reference `$parameters`: the reference is shared among all task roles.
-            Specify name and value of all the referencable parameters that will be used in the whole job template.
-            Can be referenced by `<% $parameters.param1 %>`, `<% $parameters.param2 %>`.
-          additionalProperties: true
-          example:
-            model: resnet20
-            batchsize: 32
-        secrets:
-          type: object
-          description: |
-            If sensitive information including password or API key is needed in the protocol,
-            it should be specified here in secrets section and referenced as `$secrets`.
-            Scope of reference `$secrets`: the reference is shared among all task roles and docker image's `auth` field.
-            A system that supports PAI protocol should keep the secret information away from
-            unauthorized users (how to define unauthorized user is out of the scope of this protocol).
-            For example, the yaml file used for job cloning, the stdout/stderr should protect all information marked as secrets.
-            Specify name and value of all secrets that will be used in the whole job template.
-            Can be referenced by `<% $secrets.secret1 %>`, `<% $secrets.secret2 %>`.
-          additionalProperties: true
-          example:
-            docker_password: password
-            github_token: cGFzc3dvcmQ=
-        jobRetryCount:
-          type: integer
-          description: Default is 0.
-          minimum: 0
-          example: 1
-        taskRoles:
-          type: object
-          description: |
-            Task roles are different types of task in the protocol. One job may have one or more task roles,
-            each task role has one or more instances, and each instance runs inside one container.
-          additionalProperties:
-            type: object
-            description: Property name of the taskRole should be in ^[a-zA-Z_][a-zA-Z0-9_]*$ format (valid C variable name).
-            properties:
-              instances:
-                type: integer
-                description: Default is 1, instances of a taskRole, no less than 1.
-                minimum: 1
-              completion:
-                type: object
-                description: Completion poclicy for the job, https://github.com/Microsoft/pai/blob/master/subprojects/frameworklauncher/yarn/doc/USERMANUAL.md#ApplicationCompletionPolicy.
-                properties:
-                  minFailedInstances:
-                    type: integer
-                    description: |
-                      Number of failed tasks to fail the entire job, -1 or no less than 1,
-                      if set to -1 means the job will always succeed regardless any task failure.
-                      Default is 1.
-                  minSucceededInstances:
-                    type: integer
-                    description: |
-                      Number of succeeded tasks to succeed the entire job, -1 or no less than 1,
-                      if set to -1 means the job will only succeed until all tasks are completed and minFailedInstances is not triggered.
-                      Default is task instances.
-              taskRetryCount:
-                type: integer
-                description: Default is 0.
-                minimum: 0
-              dockerImage:
-                type: string
-                description: Should reference to a dockerimage defined in prerequisites.
-              data:
-                type: string
-                description: |
-                  Select data defined in prerequisites, target can be referenced as `$data` in this task role.
-                  Scope of the reference `$data`, '$output', `$script`: the reference is only valid inside this task role.
-                  User cannot reference them from another task role. Reference for `$parameters` is global and shared among task roles.
-              output:
-                type: string
-                description: Select output defined in prerequisites, target can be referenced as `$output` in this task role.
-              script:
-                type: string
-                description: Select script defined in prerequisites, target can be referenced as `$script` in this task role.
-              extraContainerOptions:
-                type: object
-                properties:
-                  shmMB:
-                    type: integer
-                    description: Config the /dev/shm in a docker container, https://docs.docker.com/compose/compose-file/#shm_size.
-                  infiniband:
-                    type: boolean
-                    description: Use InfiniBand devices or not in a docker container.
-              resourcePerInstance:
-                type: object
-                properties:
-                  cpu:
-                    type: integer
-                    description: CPU number, unit is CPU vcore.
-                  memoryMB:
-                    type: integer
-                    description: Memory number, unit is MB.
-                  gpu:
-                    type: integer
-                    description: GPU number, unit is GPU card.
-                  ports:
-                    type: object
-                    description: Optional, only for host network, property name is string in ^[a-zA-Z_][a-zA-Z0-9_]*$ format (valid C variable name).
-                    additionalProperties:
-                      type: integer
-                      description: Port number for the port label.
-              commands:
-                type: array
-                items:
+    DockerImageComponent:
+      allOf:
+        - $ref: '#/components/schemas/OpenPAIComponent'
+        - type: object
+          properties:
+            type:
+              type: string
+              description: Component type.
+              enum:
+                - dockerimage
+            auth:
+              type: object
+              description: Only available when the type is dockerimage.
+              properties:
+                username:
                   type: string
-            required:
-              - dockerImage
-              - resourcePerInstance
-              - commands
-          example:
-            worker:
-              instances: 1
-              completion:
-                minFailedInstances: 1
-                minSucceededInstances: 1
-              taskRetryCount: 0
-              dockerImage: tf_example
-              data: cifar10
-              output: tensorflow_cifar10_model
-              script: tensorflow_cnnbenchmarks
-              extraContainerOptions:
-                shmMB: 64
-              resourcePerInstance:
-                cpu: 2
-                memoryMB: 16384
-                gpu: 4
-                ports:
-                  ssh: 1
-                  http: 1
-              commands:
-                - cd script_<% $script.name %>/scripts/tf_cnn_benchmarks
-                - >
-                  python tf_cnn_benchmarks.py --job_name=worker
-                  --local_parameter_device=gpu
-                  --variable_update=parameter_server
-                  --ps_hosts=$PAI_TASK_ROLE_ps_server_HOST_LIST
-                  --worker_hosts=$PAI_TASK_ROLE_worker_HOST_LIST
-                  --task_index=$PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX
-                  --data_name=<% $data.name %>
-                  --data_dir=$PAI_WORK_DIR/data_<% $data.name %>
-                  --train_dir=$PAI_WORK_DIR/output_<% $output.name %>
-                  --model=<% $parameters.model %>
-                  --batch_size=<% $parameters.batchsize %>
-            ps_server:
-              instances: 1
-              completion:
-                minFailedInstances: 1
-                minSucceededInstances: -1
-              taskRetryCount: 0
-              dockerImage: tf_example
-              data: cifar10
-              output: tensorflow_cifar10_model
-              script: tensorflow_cnnbenchmarks
-              extraContainerOptions:
-                shmMB: 64
-              resourcePerInstance:
-                cpu: 2
-                memoryMB: 8192
-                gpu: 0
-                ports:
-                  ssh: 1
-                  http: 1
-              commands:
-                - cd script_<% $script.name %>/scripts/tf_cnn_benchmarks
-                - >
-                  python tf_cnn_benchmarks.py --job_name=ps
-                  --local_parameter_device=gpu
-                  --variable_update=parameter_server
-                  --ps_hosts=$PAI_TASK_ROLE_ps_server_HOST_LIST
-                  --worker_hosts=$PAI_TASK_ROLE_worker_HOST_LIST
-                  --task_index=$PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX
-                  --data_dir=$PAI_WORK_DIR/data_<% $data.name %>
-                  --data_name=<% $data.name %>
-                  --train_dir=$PAI_WORK_DIR/output_<% $output.name %>
-                  --model=<% $parameters.model %>
-                  --batch_size=<% $parameters.batchsize %>
-        deployments:
-          type: array
-          description: |
-            To handle that a component may interact with different component differently, user is encouraged to place the codes handling such difference in the "deployments" field,
-            e.g., a job may get input data through wget, hdfs -dfs cp, copy, or just directly read from remote storage. This logic can be placed here.
-            In summary, the deployments field is responsible to make sure the job to run properly in a deployment specific runtime environment.
-            One could have many deployments, but only one deployment can be activated at runtime by specifying in "defaults". User can choose the deployment and specify in "defaults" at submission time.
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-              taskRoles:
-                type: object
-                additionalProperties:
-                  type: object
-                  description: Property name should be in taskRoles.
-                  properties:
-                    preCommands:
-                      type: array
-                      description: Execute before the taskRole's command.
-                      items:
-                        type: string
-                      minItems: 1
-                    postCommands:
-                      type: array
-                      description: Execute after the taskRole's command.
-                      items:
-                        type: string
-                      minItems: 1
+                password:
+                  type: string
+                  description: If a password is needed, it should be referenced as a secret.
+                registryuri:
+                  type: string
+            uri:
+              type: string
           required:
             - name
+            - type
+            - uri
           example:
-            # This implementation will download the data to local disk, and the computed model will be output to local disk first and then being copied to hdfs.
-            - name: prod
-              taskRoles:
-                worker:
-                  preCommands:
-                    # If local data cache deployed, one can copy data from local cache, only wget in case of cache miss.
-                    - wget <% $data.uri[0] %> -P data_<% $data.name %>
-                    - >
-                      git clone https://<% $script.contributor %>:<% $secrets.github_token %>@<% $script.uri %> script_<% $script.name %> &&
-                      cd script_<% $script.name %> && git checkout <% $script.version %> && cd ..
-                ps_server:
-                  preCommands:
-                    - wget <% $data.uri[0] %> -P data_<% $data.name %>
-                    - >
-                      git clone https://<% $script.contributor %>:<% $secrets.github_token %>@<% $script.uri %> script_<% $script.name %> &&
-                      cd script_<% $script.name %> && git checkout <% $script.version %> && cd ..
-                    # Then the system will go ahead to execute ps_server's command.
-                  postCommands:
-                    # After the execution of ps_server's command, the system goes here.
-                    - hdfs dfs -cp output_<% $output.name %> <% $output.uri %>
-                    # Assume the model is output locally, and this command copies the local output to hdfs. One can output to hdfs directly.
-                    # In this case, you will have to change "--train_dir=$PAI_WORK_DIR/output_<% $output.name %>".
-        defaults:
-          type: object
-          description: Optional, default cluster specific settings.
+            protocolVersion: 2
+            name: tf_example
+            type: dockerimage
+            version: latest
+            contributor: Alice
+            description: python3.5, tensorflow
+            auth:
+              username: user
+              password: <% $secrets.docker_password %>
+              registryuri: openpai.azurecr.io
+            uri: openpai/pai.example.tensorflow
+    ScriptOrOutputComponent:
+      allOf:
+        - $ref: '#/components/schemas/OpenPAIComponent'
+        - type: object
           properties:
-            virtualCluster:
+            type:
               type: string
-            deployment:
+              description: Component type.
+              enum:
+                - script
+                - output
+            uri:
               type: string
-              description: Should reference to deployment defined in deployments.
+          required:
+            - name
+            - type
+            - uri
           example:
-            # Use prod deployment in job submission.
-            deployment: prod
-        extras:
-          type: object
-          description: Extra field, save any information that plugin may use.
+            output_example:
+              value:
+                protocolVersion: 2
+                name: tensorflow_cifar10_model
+                type: output
+                version: latest
+                contributor: Alice
+                description: cifar10 data output
+                uri: hdfs://10.151.40.179:9000/core/cifar10_model
+            script_example:
+              value:
+                protocolVersion: 2
+                name: tensorflow_cnnbenchmarks
+                type: script
+                version: 84820935288cab696c9c2ac409cbd46a1f24723d
+                contributor: MaggieQi
+                description: tensorflow benchmarks
+                uri: github.com/MaggieQi/benchmarks
+    DataComponent:
+      allOf:
+        - $ref: '#/components/schemas/OpenPAIComponent'
+        - type: object
           properties:
-            submitFrom:
+            type:
               type: string
-              example: submit-job-v2
-            gangAllocation:
-              type: boolean
-              description: Gang scheduling or not.
-              example: true
-            hivedScheduler:
+              description: Component type.
+              enum:
+                - data
+            uri:
+              type: array
+              items:
+                type: string
+              minItems: 1
+          required:
+            - type
+            - uri
+          example:
+            protocolVersion: 2
+            name: cifar10
+            type: data
+            version: latest
+            contributor: Alice
+            description: cifar10 dataset, image classification
+            uri:
+              - https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+    JobProtocol:
+      allOf:
+        - $ref: '#/components/schemas/OpenPAIComponent'
+        - type: object
+          description: Job protocol specification.
+          properties:
+            type:
+              type: string
+              description: Component type, should be "job" here.
+              enum:
+                - job
+              example: job
+            prerequisites:
+              type: array
+              description: Each item is the protocol for data, script, dockerimage, or output type.
+              items:
+                oneOf:
+                  - $ref: '#/components/schemas/DockerImageComponent'
+                  - $ref: '#/components/schemas/ScriptOrOutputComponent'
+                  - $ref: '#/components/schemas/DataComponent'
+              minItems: 1
+            parameters:
               type: object
-              description: Hived scheduler configurations.
-              properties:
-                jobPriorityClass:
-                  type: string
-                  description: Priority class for the job, oppo is the lowest priority.
-                  enum:
-                    - crit
-                    - prod
-                    - test
-                    - oppo
-                taskRoles:
-                  type: object
-                  additionalProperties:
+              description: |
+                If specified, the whole parameters object can be referenced as `$parameters`.
+                Scope of reference `$parameters`: the reference is shared among all task roles.
+                Specify name and value of all the referencable parameters that will be used in the whole job template.
+                Can be referenced by `<% $parameters.param1 %>`, `<% $parameters.param2 %>`.
+              additionalProperties: true
+              example:
+                model: resnet20
+                batchsize: 32
+            secrets:
+              type: object
+              description: |
+                If sensitive information including password or API key is needed in the protocol,
+                it should be specified here in secrets section and referenced as `$secrets`.
+                Scope of reference `$secrets`: the reference is shared among all task roles and docker image's `auth` field.
+                A system that supports PAI protocol should keep the secret information away from
+                unauthorized users (how to define unauthorized user is out of the scope of this protocol).
+                For example, the yaml file used for job cloning, the stdout/stderr should protect all information marked as secrets.
+                Specify name and value of all secrets that will be used in the whole job template.
+                Can be referenced by `<% $secrets.secret1 %>`, `<% $secrets.secret2 %>`.
+              additionalProperties: true
+              example:
+                docker_password: password
+                github_token: cGFzc3dvcmQ=
+            jobRetryCount:
+              type: integer
+              description: Default is 0.
+              minimum: 0
+              example: 1
+            taskRoles:
+              type: object
+              description: |
+                Task roles are different types of task in the protocol. One job may have one or more task roles,
+                each task role has one or more instances, and each instance runs inside one container.
+              additionalProperties:
+                type: object
+                description: Property name of the taskRole should be in ^[a-zA-Z_][a-zA-Z0-9_]*$ format (valid C variable name).
+                properties:
+                  instances:
+                    type: integer
+                    description: Default is 1, instances of a taskRole, no less than 1.
+                    minimum: 1
+                  completion:
+                    type: object
+                    description: Completion poclicy for the job, https://github.com/Microsoft/pai/blob/master/subprojects/frameworklauncher/yarn/doc/USERMANUAL.md#ApplicationCompletionPolicy.
+                    properties:
+                      minFailedInstances:
+                        type: integer
+                        description: |
+                          Number of failed tasks to fail the entire job, -1 or no less than 1,
+                          if set to -1 means the job will always succeed regardless any task failure.
+                          Default is 1.
+                      minSucceededInstances:
+                        type: integer
+                        description: |
+                          Number of succeeded tasks to succeed the entire job, -1 or no less than 1,
+                          if set to -1 means the job will only succeed until all tasks are completed and minFailedInstances is not triggered.
+                          Default is task instances.
+                  taskRetryCount:
+                    type: integer
+                    description: Default is 0.
+                    minimum: 0
+                  dockerImage:
+                    type: string
+                    description: Should reference to a dockerimage defined in prerequisites.
+                  data:
+                    type: string
+                    description: |
+                      Select data defined in prerequisites, target can be referenced as `$data` in this task role.
+                      Scope of the reference `$data`, '$output', `$script`: the reference is only valid inside this task role.
+                      User cannot reference them from another task role. Reference for `$parameters` is global and shared among task roles.
+                  output:
+                    type: string
+                    description: Select output defined in prerequisites, target can be referenced as `$output` in this task role.
+                  script:
+                    type: string
+                    description: Select script defined in prerequisites, target can be referenced as `$script` in this task role.
+                  extraContainerOptions:
                     type: object
                     properties:
-                      skuType:
-                        type: string
-                      affinityGroupName:
-                        type: string
-              example: null
-      required:
-        - protocolVersion
-        - name
-        - type
-        - prerequisites
-        - taskRoles
+                      shmMB:
+                        type: integer
+                        description: Config the /dev/shm in a docker container, https://docs.docker.com/compose/compose-file/#shm_size.
+                      infiniband:
+                        type: boolean
+                        description: Use InfiniBand devices or not in a docker container.
+                  resourcePerInstance:
+                    type: object
+                    properties:
+                      cpu:
+                        type: integer
+                        description: CPU number, unit is CPU vcore.
+                      memoryMB:
+                        type: integer
+                        description: Memory number, unit is MB.
+                      gpu:
+                        type: integer
+                        description: GPU number, unit is GPU card.
+                      ports:
+                        type: object
+                        description: Optional, only for host network, property name is string in ^[a-zA-Z_][a-zA-Z0-9_]*$ format (valid C variable name).
+                        additionalProperties:
+                          type: integer
+                          description: Port number for the port label.
+                  commands:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - dockerImage
+                  - resourcePerInstance
+                  - commands
+              example:
+                worker:
+                  instances: 1
+                  completion:
+                    minFailedInstances: 1
+                    minSucceededInstances: 1
+                  taskRetryCount: 0
+                  dockerImage: tf_example
+                  data: cifar10
+                  output: tensorflow_cifar10_model
+                  script: tensorflow_cnnbenchmarks
+                  extraContainerOptions:
+                    shmMB: 64
+                  resourcePerInstance:
+                    cpu: 2
+                    memoryMB: 16384
+                    gpu: 4
+                    ports:
+                      ssh: 1
+                      http: 1
+                  commands:
+                    - cd script_<% $script.name %>/scripts/tf_cnn_benchmarks
+                    - >
+                      python tf_cnn_benchmarks.py --job_name=worker
+                      --local_parameter_device=gpu
+                      --variable_update=parameter_server
+                      --ps_hosts=$PAI_TASK_ROLE_ps_server_HOST_LIST
+                      --worker_hosts=$PAI_TASK_ROLE_worker_HOST_LIST
+                      --task_index=$PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX
+                      --data_name=<% $data.name %>
+                      --data_dir=$PAI_WORK_DIR/data_<% $data.name %>
+                      --train_dir=$PAI_WORK_DIR/output_<% $output.name %>
+                      --model=<% $parameters.model %>
+                      --batch_size=<% $parameters.batchsize %>
+                ps_server:
+                  instances: 1
+                  completion:
+                    minFailedInstances: 1
+                    minSucceededInstances: -1
+                  taskRetryCount: 0
+                  dockerImage: tf_example
+                  data: cifar10
+                  output: tensorflow_cifar10_model
+                  script: tensorflow_cnnbenchmarks
+                  extraContainerOptions:
+                    shmMB: 64
+                  resourcePerInstance:
+                    cpu: 2
+                    memoryMB: 8192
+                    gpu: 0
+                    ports:
+                      ssh: 1
+                      http: 1
+                  commands:
+                    - cd script_<% $script.name %>/scripts/tf_cnn_benchmarks
+                    - >
+                      python tf_cnn_benchmarks.py --job_name=ps
+                      --local_parameter_device=gpu
+                      --variable_update=parameter_server
+                      --ps_hosts=$PAI_TASK_ROLE_ps_server_HOST_LIST
+                      --worker_hosts=$PAI_TASK_ROLE_worker_HOST_LIST
+                      --task_index=$PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX
+                      --data_dir=$PAI_WORK_DIR/data_<% $data.name %>
+                      --data_name=<% $data.name %>
+                      --train_dir=$PAI_WORK_DIR/output_<% $output.name %>
+                      --model=<% $parameters.model %>
+                      --batch_size=<% $parameters.batchsize %>
+            deployments:
+              type: array
+              description: |
+                To handle that a component may interact with different component differently, user is encouraged to place the codes handling such difference in the "deployments" field,
+                e.g., a job may get input data through wget, hdfs -dfs cp, copy, or just directly read from remote storage. This logic can be placed here.
+                In summary, the deployments field is responsible to make sure the job to run properly in a deployment specific runtime environment.
+                One could have many deployments, but only one deployment can be activated at runtime by specifying in "defaults". User can choose the deployment and specify in "defaults" at submission time.
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  taskRoles:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      description: Property name should be in taskRoles.
+                      properties:
+                        preCommands:
+                          type: array
+                          description: Execute before the taskRole's command.
+                          items:
+                            type: string
+                          minItems: 1
+                        postCommands:
+                          type: array
+                          description: Execute after the taskRole's command.
+                          items:
+                            type: string
+                          minItems: 1
+              required:
+                - name
+              example:
+                # This implementation will download the data to local disk, and the computed model will be output to local disk first and then being copied to hdfs.
+                - name: prod
+                  taskRoles:
+                    worker:
+                      preCommands:
+                        # If local data cache deployed, one can copy data from local cache, only wget in case of cache miss.
+                        - wget <% $data.uri[0] %> -P data_<% $data.name %>
+                        - >
+                          git clone https://<% $script.contributor %>:<% $secrets.github_token %>@<% $script.uri %> script_<% $script.name %> &&
+                          cd script_<% $script.name %> && git checkout <% $script.version %> && cd ..
+                    ps_server:
+                      preCommands:
+                        - wget <% $data.uri[0] %> -P data_<% $data.name %>
+                        - >
+                          git clone https://<% $script.contributor %>:<% $secrets.github_token %>@<% $script.uri %> script_<% $script.name %> &&
+                          cd script_<% $script.name %> && git checkout <% $script.version %> && cd ..
+                        # Then the system will go ahead to execute ps_server's command.
+                      postCommands:
+                        # After the execution of ps_server's command, the system goes here.
+                        - hdfs dfs -cp output_<% $output.name %> <% $output.uri %>
+                        # Assume the model is output locally, and this command copies the local output to hdfs. One can output to hdfs directly.
+                        # In this case, you will have to change "--train_dir=$PAI_WORK_DIR/output_<% $output.name %>".
+            defaults:
+              type: object
+              description: Optional, default cluster specific settings.
+              properties:
+                virtualCluster:
+                  type: string
+                deployment:
+                  type: string
+                  description: Should reference to deployment defined in deployments.
+              example:
+                # Use prod deployment in job submission.
+                deployment: prod
+            extras:
+              type: object
+              description: Extra field, save any information that plugin may use.
+              properties:
+                submitFrom:
+                  type: string
+                  example: submit-job-v2
+                gangAllocation:
+                  type: boolean
+                  description: Gang scheduling or not.
+                  example: true
+                hivedScheduler:
+                  type: object
+                  description: Hived scheduler configurations.
+                  properties:
+                    jobPriorityClass:
+                      type: string
+                      description: Priority class for the job, oppo is the lowest priority.
+                      enum:
+                        - crit
+                        - prod
+                        - test
+                        - oppo
+                    taskRoles:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          skuType:
+                            type: string
+                          affinityGroupName:
+                            type: string
+                  example: null
+          required:
+            - protocolVersion
+            - name
+            - type
+            - prerequisites
+            - taskRoles

--- a/schemas/v2/schema.yaml
+++ b/schemas/v2/schema.yaml
@@ -10,7 +10,7 @@ externalDocs:
 paths: {}
 components:
   schemas:
-    OpenPAIComponent:
+    PrerequisiteInfo:
       type: object
       properties:
         protocolVersion:
@@ -35,10 +35,10 @@ components:
           example: OpenPAI
         description:
           type: string
-          example: Here is the job description.
-    DockerImageComponent:
+          example: Here is the description.
+    DockerImagePrerequisite:
       allOf:
-        - $ref: '#/components/schemas/OpenPAIComponent'
+        - $ref: '#/components/schemas/PrerequisiteInfo'
         - type: object
           properties:
             type:
@@ -63,21 +63,9 @@ components:
             - name
             - type
             - uri
-          example:
-            protocolVersion: 2
-            name: tf_example
-            type: dockerimage
-            version: latest
-            contributor: Alice
-            description: python3.5, tensorflow
-            auth:
-              username: user
-              password: <% $secrets.docker_password %>
-              registryuri: openpai.azurecr.io
-            uri: openpai/pai.example.tensorflow
-    ScriptOrOutputComponent:
+    ScriptOrOutputPrerequisite:
       allOf:
-        - $ref: '#/components/schemas/OpenPAIComponent'
+        - $ref: '#/components/schemas/PrerequisiteInfo'
         - type: object
           properties:
             type:
@@ -92,28 +80,9 @@ components:
             - name
             - type
             - uri
-          example:
-            output_example:
-              value:
-                protocolVersion: 2
-                name: tensorflow_cifar10_model
-                type: output
-                version: latest
-                contributor: Alice
-                description: cifar10 data output
-                uri: hdfs://10.151.40.179:9000/core/cifar10_model
-            script_example:
-              value:
-                protocolVersion: 2
-                name: tensorflow_cnnbenchmarks
-                type: script
-                version: 84820935288cab696c9c2ac409cbd46a1f24723d
-                contributor: MaggieQi
-                description: tensorflow benchmarks
-                uri: github.com/MaggieQi/benchmarks
-    DataComponent:
+    DataPrerequisite:
       allOf:
-        - $ref: '#/components/schemas/OpenPAIComponent'
+        - $ref: '#/components/schemas/PrerequisiteInfo'
         - type: object
           properties:
             type:
@@ -129,18 +98,9 @@ components:
           required:
             - type
             - uri
-          example:
-            protocolVersion: 2
-            name: cifar10
-            type: data
-            version: latest
-            contributor: Alice
-            description: cifar10 dataset, image classification
-            uri:
-              - https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
     JobProtocol:
       allOf:
-        - $ref: '#/components/schemas/OpenPAIComponent'
+        - $ref: '#/components/schemas/PrerequisiteInfo'
         - type: object
           description: Job protocol specification.
           properties:
@@ -155,10 +115,44 @@ components:
               description: Each item is the protocol for data, script, dockerimage, or output type.
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/DockerImageComponent'
-                  - $ref: '#/components/schemas/ScriptOrOutputComponent'
-                  - $ref: '#/components/schemas/DataComponent'
+                  - $ref: '#/components/schemas/DockerImagePrerequisite'
+                  - $ref: '#/components/schemas/ScriptOrOutputPrerequisite'
+                  - $ref: '#/components/schemas/DataPrerequisite'
               minItems: 1
+              example:
+                - protocolVersion: 2
+                  name: tf_example
+                  type: dockerimage
+                  version: latest
+                  contributor: Alice
+                  description: python3.5, tensorflow
+                  auth:
+                    username: user
+                    password: <% $secrets.docker_password %>
+                    registryuri: openpai.azurecr.io
+                  uri: openpai/pai.example.tensorflow
+                - protocolVersion: 2
+                  name: tensorflow_cifar10_model
+                  type: output
+                  version: latest
+                  contributor: Alice
+                  description: cifar10 data output
+                  uri: hdfs://10.151.40.179:9000/core/cifar10_model
+                - protocolVersion: 2
+                  name: tensorflow_cnnbenchmarks
+                  type: script
+                  version: 84820935288cab696c9c2ac409cbd46a1f24723d
+                  contributor: MaggieQi
+                  description: tensorflow benchmarks
+                  uri: github.com/MaggieQi/benchmarks
+                - protocolVersion: 2
+                  name: cifar10
+                  type: data
+                  version: latest
+                  contributor: Alice
+                  description: cifar10 dataset, image classification
+                  uri:
+                    - https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
             parameters:
               type: object
               description: |

--- a/schemas/v2/schema.yaml
+++ b/schemas/v2/schema.yaml
@@ -22,7 +22,7 @@ components:
         name:
           type: string
           description: String in ^[a-zA-Z0-9_-]+$ format, no longer than 255 characters.
-          pattern: '^[a-zA-Z0-9_-]+$'
+          pattern: "^[a-zA-Z0-9_-]+$"
           minLength: 1
           maxLength: 255
           example: tensorflow_distributed_training
@@ -38,7 +38,7 @@ components:
           example: Here is the description.
     DockerImagePrerequisite:
       allOf:
-        - $ref: '#/components/schemas/PrerequisiteInfo'
+        - $ref: "#/components/schemas/PrerequisiteInfo"
         - type: object
           properties:
             type:
@@ -65,7 +65,7 @@ components:
             - uri
     ScriptOrOutputPrerequisite:
       allOf:
-        - $ref: '#/components/schemas/PrerequisiteInfo'
+        - $ref: "#/components/schemas/PrerequisiteInfo"
         - type: object
           properties:
             type:
@@ -82,7 +82,7 @@ components:
             - uri
     DataPrerequisite:
       allOf:
-        - $ref: '#/components/schemas/PrerequisiteInfo'
+        - $ref: "#/components/schemas/PrerequisiteInfo"
         - type: object
           properties:
             type:
@@ -100,7 +100,7 @@ components:
             - uri
     JobProtocol:
       allOf:
-        - $ref: '#/components/schemas/PrerequisiteInfo'
+        - $ref: "#/components/schemas/PrerequisiteInfo"
         - type: object
           description: Job protocol specification.
           properties:
@@ -115,9 +115,9 @@ components:
               description: Each item is the protocol for data, script, dockerimage, or output type.
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/DockerImagePrerequisite'
-                  - $ref: '#/components/schemas/ScriptOrOutputPrerequisite'
-                  - $ref: '#/components/schemas/DataPrerequisite'
+                  - $ref: "#/components/schemas/DockerImagePrerequisite"
+                  - $ref: "#/components/schemas/ScriptOrOutputPrerequisite"
+                  - $ref: "#/components/schemas/DataPrerequisite"
               minItems: 1
               example:
                 - protocolVersion: 2


### PR DESCRIPTION
Since the protocol allow different version between job (root) and components (e.g. docker image, data in `prerequisites`), thus it is better to separate them to independent components